### PR TITLE
Implement #4 Remove the unpatched behavior of the Frequency-CV attenuverter

### DIFF
--- a/eurorack/plaits/dsp/voice.h
+++ b/eurorack/plaits/dsp/voice.h
@@ -201,9 +201,9 @@ class Voice {
         ? (use_internal_envelope
             ? cv_modulation_amount * external_modulation + lpg_modulation_amount * envelope
             : cv_modulation_amount * external_modulation)
-        : (use_internal_envelope 
-            ? lpg_modulation_amount * envelope + cv_modulation_amount * default_internal_modulation
-            : cv_modulation_amount * default_internal_modulation);
+        : (use_internal_envelope  //Removed unpatched attenuverter finetuning from the next 2 lines for Atelier/Palette
+            ? lpg_modulation_amount * envelope
+            : 0);
 
     CONSTRAIN(value, minimum_value, maximum_value);
     return value;

--- a/eurorack/plaits/dsp/voice.h
+++ b/eurorack/plaits/dsp/voice.h
@@ -201,7 +201,7 @@ class Voice {
         ? (use_internal_envelope
             ? cv_modulation_amount * external_modulation + lpg_modulation_amount * envelope
             : cv_modulation_amount * external_modulation)
-        : (use_internal_envelope  //Removed unpatched attenuverter finetuning from the next 2 lines for Atelier/Palette
+        : (use_internal_envelope
             ? lpg_modulation_amount * envelope
             : 0);
 


### PR DESCRIPTION
Implements #4 

When the Frequency-CV attenuverter is closed (12 o'clock), `cv_modulation_amount == 0`. This patch ensures that it is always considered zero so long as the Frequency CV input is not connected (`use_external_modulation == false`).