### PR TITLE
(Fix #3) LPG-Harmonics: Remove unwarranted special treatment

### DIFF
--- a/eurorack/plaits/dsp/voice.cc
+++ b/eurorack/plaits/dsp/voice.cc
@@ -205,7 +205,7 @@ void Voice::Render(
       modulations.harmonics_patched,
       modulations.harmonics,
       use_internal_envelope,
-      internal_envelope_amplitude * decay_envelope_.value(),
+      decay_envelope_.value(),
       0.0f,
       0.0f,
       1.0f);


### PR DESCRIPTION
Fixes #3 

Morph and Frequency (Note) get special treatment in the case of the Speech Synthesis engine, because their LPG modulation knobs change function when Harmonics is above a certain value. The LPG-Harmonics knob has no such change in function, and so should not receive this special treatment.

The `internal_envelope_amplitude` float only serves any purpose for the Speech Synthesis engine: in all other cases its value is always `1.0` and it is only ever used multiplicatively. This multiplication should only apply to `p.note` and `p.morph`: this is the special treatment which serves to transition the knobs to their alternate functions.

Here I remove this multiplication, bringing consistency with the code for `p.timbre` above.