### PR TITLE
(Fix #5) Speech Engine: Take into account Harmonics-CV Attenuverter

### DIFF
--- a/eurorack/plaits/dsp/voice.cc
+++ b/eurorack/plaits/dsp/voice.cc
@@ -146,7 +146,7 @@ void Voice::Render(
 
   // Actual synthesis parameters.
 
-  p.harmonics = patch.harmonics + modulations.harmonics;
+  p.harmonics = patch.harmonics + modulations.harmonics * patch.harmonics_cv_amount;
   CONSTRAIN(p.harmonics, 0.0f, 1.0f);
 
   float internal_envelope_amplitude = 1.0f;


### PR DESCRIPTION
Fixes #5 

The state of the Harmonics CV attenuverter should be accounted for before the speech-engine-specific adjustments (potential intonation and speed modulation) are applied.