### PR TITLE
Fix out of bounds access

### DIFF
--- a/eurorack/plaits/dsp/engine/chord_engine.cc
+++ b/eurorack/plaits/dsp/engine/chord_engine.cc
@@ -60,13 +60,13 @@ void ChordEngine::Init(BufferAllocator* allocator) {
   morph_lp_ = 0.0f;
   timbre_lp_ = 0.0f;
   
-  ratios_ = allocator->Allocate<float>(kChordNumChords * kChordNumVoices);
+  ratios_ = allocator->Allocate<float>(kChordNumChords * kChordNumNotes);
 }
 
 void ChordEngine::Reset() {
   for (int i = 0; i < kChordNumChords; ++i) {
-    for (int j = 0; j < kChordNumVoices; ++j) {
-      ratios_[i * kChordNumVoices + j] = SemitonesToRatio(chords[i][j]);
+    for (int j = 0; j < kChordNumNotes; ++j) {
+      ratios_[i * kChordNumNotes + j] = SemitonesToRatio(chords[i][j]);
     }
   }
 }
@@ -105,7 +105,7 @@ int ChordEngine::ComputeChordInversion(
     float inversion,
     float* ratios,
     float* amplitudes) {
-  const float* base_ratio = &ratios_[chord_index * kChordNumVoices];
+  const float* base_ratio = &ratios_[chord_index * kChordNumNotes];
   inversion = inversion * float(kChordNumNotes * 5);
 
   MAKE_INTEGRAL_FRACTIONAL(inversion);


### PR DESCRIPTION
Reported by GCC9 under Linux
```
Atelier/eurorack/plaits/dsp/engine/chord_engine.cc: In member function 'Atelierplaits::ChordEngine::Reset()':
Atelier/eurorack/plaits/dsp/engine/chord_engine.cc:69:70: error: iteration 4 invokes undefined behavior [-Werror=aggressive-loop-optimizations]
   69 |       ratios_[i * kChordNumVoices + j] = SemitonesToRatio(chords[i][j]);
      |                                                           ~~~~~~~~~~~^
Atelier/eurorack/plaits/dsp/engine/chord_engine.cc:68:23: note: within this loop
   68 |     for (int j = 0; j < kChordNumVoices; ++j) {
      |                     ~~^~~~~~~~~~~~~~~~~
      
```

I took the fixes from the upstream repo, based on https://github.com/pichenettes/eurorack/commit/99432f2bf443219b3eb77e65e1a18583faad422e
